### PR TITLE
Add license resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ baton resources
 - Sites
 - Users
 - Groups
+- Licenses
 
 # Contributing, Support and Issues
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -32,6 +32,13 @@ var (
 			v2.ResourceType_TRAIT_GROUP,
 		},
 	}
+	resourceTypeLicense = &v2.ResourceType{
+		Id:          "license",
+		DisplayName: "License",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_ROLE,
+		},
+	}
 )
 
 type Tableau struct {
@@ -83,5 +90,6 @@ func (tb *Tableau) ResourceSyncers(ctx context.Context) []connectorbuilder.Resou
 		userBuilder(tb.client),
 		siteBuilder(tb.client),
 		groupBuilder(tb.client),
+		licenseBuilder(tb.client),
 	}
 }

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -1,0 +1,127 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-tableau/pkg/tableau"
+
+	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+var licences = []string{creator, explorer, viewer, unlicensed}
+var RolesPerLicense = map[string][]string{
+	creator:    {siteAdministratorCreator, creator},
+	explorer:   {siteAdministratorExplorer, explorerCanPublish, explorer, readOnly, siteAdministrator},
+	viewer:     {viewer},
+	unlicensed: {unlicensed},
+}
+
+type licenseResourceType struct {
+	resourceType *v2.ResourceType
+	client       *tableau.Client
+}
+
+func (l *licenseResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return l.resourceType
+}
+
+// Create a new connector resource for a Tableau License.
+func licenseResource(license string) (*v2.Resource, error) {
+	licenseID := strings.ToLower(license)
+	profile := map[string]interface{}{
+		"license_name": license,
+		"license_id":   licenseID,
+	}
+
+	roleTraitOptions := []rs.RoleTraitOption{
+		rs.WithRoleProfile(profile),
+	}
+
+	ret, err := rs.NewRoleResource(license, resourceTypeLicense, licenseID, roleTraitOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (l *licenseResourceType) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	var rv []*v2.Resource
+
+	for _, license := range licences {
+		sr, err := licenseResource(license)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		rv = append(rv, sr)
+	}
+
+	return rv, "", nil, nil
+}
+
+func (l *licenseResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+	var rv []*v2.Entitlement
+
+	assigmentOptions := []ent.EntitlementOption{
+		ent.WithGrantableTo(resourceTypeUser),
+		ent.WithDescription(fmt.Sprintf("Member of %s License in Tableau", resource.DisplayName)),
+		ent.WithDisplayName(fmt.Sprintf("%s License %s", resource.DisplayName, memberEntitlement)),
+	}
+
+	en := ent.NewAssignmentEntitlement(resource, memberEntitlement, assigmentOptions...)
+	rv = append(rv, en)
+
+	return rv, "", nil, nil
+}
+
+func (l *licenseResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	users, err := l.client.GetPaginatedUsers(ctx)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	var rv []*v2.Grant
+	for _, user := range users {
+		userCopy := user
+		ur, err := userResource(ctx, &userCopy, resource.Id)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		if licenseContainsRole(resource.DisplayName, user.SiteRole, RolesPerLicense) {
+			gr := grant.NewGrant(resource, memberEntitlement, ur.Id)
+			rv = append(rv, gr)
+		}
+	}
+
+	return rv, "", nil, nil
+}
+
+func licenseBuilder(client *tableau.Client) *licenseResourceType {
+	return &licenseResourceType{
+		resourceType: resourceTypeLicense,
+		client:       client,
+	}
+}
+
+func licenseContainsRole(license string, role string, licencesMap map[string][]string) bool {
+	slice, ok := licencesMap[license]
+	if !ok {
+		return false
+	}
+
+	for _, value := range slice {
+		if value == role {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -8,10 +8,11 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+
 	"github.com/conductorone/baton-tableau/pkg/tableau"
 
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
-	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
@@ -82,7 +83,7 @@ func (l *licenseResourceType) Entitlements(_ context.Context, resource *v2.Resou
 }
 
 func (l *licenseResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	users, err := l.client.GetPaginatedUsers(ctx)
+	users, token, err := l.client.GetUsersPage(ctx, pt.Token)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -101,7 +102,7 @@ func (l *licenseResourceType) Grants(ctx context.Context, resource *v2.Resource,
 		}
 	}
 
-	return rv, "", nil, nil
+	return rv, token, nil, nil
 }
 
 func licenseBuilder(client *tableau.Client) *licenseResourceType {

--- a/pkg/connector/site.go
+++ b/pkg/connector/site.go
@@ -16,17 +16,30 @@ import (
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
+const (
+	siteAdministrator         = "SiteAdministrator"
+	siteAdministratorCreator  = "SiteAdministratorCreator"
+	siteAdministratorExplorer = "SiteAdministratorExplorer"
+	serverAdministrator       = "ServerAdministrator"
+	creator                   = "Creator"
+	explorer                  = "Explorer"
+	explorerCanPublish        = "ExplorerCanPublish"
+	viewer                    = "Viewer"
+	unlicensed                = "Unlicensed"
+	readOnly                  = "ReadOnly"
+)
+
 var roles = map[string]string{
-	"SiteAdministrator":         "site administrator",
-	"SiteAdministratorCreator":  "site administrator creator",
-	"SiteAdministratorExplorer": "site administrator explorer",
-	"ServerAdministrator":       "server administrator",
-	"Creator":                   "creator",
-	"Explorer":                  "explorer",
-	"ExplorerCanPublish":        "explorer can publish",
-	"Viewer":                    "viewer",
-	"Unlicensed":                "unlicensed",
-	"ReadOnly":                  "readonly",
+	siteAdministrator:         "site administrator",
+	siteAdministratorCreator:  "site administrator creator",
+	siteAdministratorExplorer: "site administrator explorer",
+	serverAdministrator:       "server administrator",
+	creator:                   "creator",
+	explorer:                  "explorer",
+	explorerCanPublish:        "explorer can publish",
+	viewer:                    "viewer",
+	unlicensed:                "unlicensed",
+	readOnly:                  "readonly",
 }
 
 type siteResourceType struct {


### PR DESCRIPTION
Syncs licences. Roles are part of licences so for each user we check their role and map it to the License resource.