### PR TITLE
update getConnector to follow existent c1 implementation

### DIFF
--- a/cmd/baton-tableau/main.go
+++ b/cmd/baton-tableau/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/field"
@@ -48,13 +49,10 @@ func getConnector(ctx context.Context, tc *cfg.Tableau) (types.ConnectorServer, 
 		return nil, err
 	}
 
-	apiVersion := tc.ApiVersion
-	if apiVersion == "" {
-		apiVersion = "3.17"
-	}
-
 	serverPath := tc.ServerPath
-	baseUrl, err := url.JoinPath("https://", serverPath, "api", apiVersion)
+	serverPath = strings.TrimPrefix(serverPath, "https://")
+	serverPath = strings.TrimPrefix(serverPath, "http://")
+	baseUrl, err := url.JoinPath("https://", serverPath, "/api/3.19")
 	if err != nil {
 		l.Error("error creating base url", zap.Error(err))
 	}

--- a/cmd/baton-tableau/main.go
+++ b/cmd/baton-tableau/main.go
@@ -49,10 +49,14 @@ func getConnector(ctx context.Context, tc *cfg.Tableau) (types.ConnectorServer, 
 		return nil, err
 	}
 
+	apiVersion := "3.19"
+	if tc.ApiVersion != "" {
+		apiVersion = tc.ApiVersion
+	}
 	serverPath := tc.ServerPath
 	serverPath = strings.TrimPrefix(serverPath, "https://")
 	serverPath = strings.TrimPrefix(serverPath, "http://")
-	baseUrl, err := url.JoinPath("https://", serverPath, "/api/3.19")
+	baseUrl, err := url.JoinPath("https://", serverPath, "api", apiVersion)
 	if err != nil {
 		l.Error("error creating base url", zap.Error(err))
 	}


### PR DESCRIPTION
Since we want to containerize baton-tableau I'm trying to follow existent c1 pattern that parses the given url before create the connector and force a default api version to 3.19 to keep this behavior after update

https://github.com/ductone/c1/blob/main/pkg/connector/tableau/tableau.go#L29-L36