### PR TITLE
[BB-1546] Return success result on account creation

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -107,7 +107,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, t
 
 	for _, user := range users {
 		userCopy := user
-		ur, err := userResource(ctx, &userCopy, resource.Id)
+		ur, err := userResource(&userCopy, resource.Id)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -97,7 +97,7 @@ func (l *licenseResourceType) Grants(ctx context.Context, resource *v2.Resource,
 	var rv []*v2.Grant
 	for _, user := range users {
 		userCopy := user
-		ur, err := userResource(ctx, &userCopy, resource.Id)
+		ur, err := userResource(&userCopy, resource.Id)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/pkg/connector/site.go
+++ b/pkg/connector/site.go
@@ -113,7 +113,7 @@ func (o *siteResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 			)
 		}
 		userCopy := user
-		ur, err := userResource(ctx, &userCopy, resource.Id)
+		ur, err := userResource(&userCopy, resource.Id)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -25,7 +25,7 @@ func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 }
 
 // Create a new connector resource for a Tableau user.
-func userResource(ctx context.Context, user *tableau.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
+func userResource(user *tableau.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	names := strings.SplitN(user.FullName, " ", 2)
 	var firstName, lastName string
 	switch len(names) {
@@ -77,7 +77,7 @@ func (o *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, to
 	var rv []*v2.Resource
 	for _, user := range users {
 		userCopy := user
-		ur, err := userResource(ctx, &userCopy, parentId)
+		ur, err := userResource(&userCopy, parentId)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -99,7 +99,6 @@ func (u *userResourceType) CreateAccountCapabilityDetails(ctx context.Context) (
 	return &v2.CredentialDetailsAccountProvisioning{
 		SupportedCredentialOptions: []v2.CapabilityDetailCredentialOption{
 			v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
-			v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_RANDOM_PASSWORD,
 		},
 		PreferredCredentialOption: v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
 	}, nil, nil
@@ -122,7 +121,7 @@ func (o *userResourceType) CreateAccount(ctx context.Context, accountInfo *v2.Ac
 		return nil, nil, nil, fmt.Errorf("baton-tableau: siteRole not found in profile")
 	}
 
-	err := o.client.AddUserToSite(ctx, tableau.CreateUserRequest{
+	user, err := o.client.AddUserToSite(ctx, tableau.CreateUserRequest{
 		Email:    email,
 		SiteRole: siteRole,
 	})
@@ -130,9 +129,13 @@ func (o *userResourceType) CreateAccount(ctx context.Context, accountInfo *v2.Ac
 		return nil, nil, nil, fmt.Errorf("baton-tableau: failed to create user %s: %w", email, err)
 	}
 
-	return &v2.CreateAccountResponse_ActionRequiredResult{
-		Message:               fmt.Sprintf("User %s invitation sent successfully", email),
-		IsCreateAccountResult: true,
+	resource, err := userResource(user, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("baton-tableau: failed to parse user resource for %s: %w", email, err)
+	}
+
+	return &v2.CreateAccountResponse_SuccessResult{
+		Resource: resource,
 	}, nil, nil, nil
 }
 

--- a/pkg/tableau/client.go
+++ b/pkg/tableau/client.go
@@ -394,10 +394,10 @@ func (c *Client) doRequest(ctx context.Context, url string, res interface{}, q u
 	return nil
 }
 
-func (c *Client) AddUserToSite(ctx context.Context, user CreateUserRequest) error {
+func (c *Client) AddUserToSite(ctx context.Context, user CreateUserRequest) (*User, error) {
 	url := fmt.Sprint(c.baseUrl, "/sites/", c.siteId, "/users")
 	var res struct {
-		User User `json:"user"`
+		User *User `json:"user"`
 	}
 
 	requestBody, err := json.Marshal(map[string]interface{}{
@@ -408,14 +408,14 @@ func (c *Client) AddUserToSite(ctx context.Context, user CreateUserRequest) erro
 	})
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := c.doRequest(ctx, url, &res, nil, requestBody, http.MethodPost); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return res.User, nil
 }
 
 func (c *Client) RemoveUserFromSite(ctx context.Context, userId string) error {

--- a/pkg/tableau/client.go
+++ b/pkg/tableau/client.go
@@ -415,6 +415,10 @@ func (c *Client) AddUserToSite(ctx context.Context, user CreateUserRequest) (*Us
 		return nil, err
 	}
 
+	if res.User == nil {
+		return nil, fmt.Errorf("failed to create user, no user returned")
+	}
+
 	return res.User, nil
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Account creation now returns the created user resource and the Tableau client returns the created user; removed random password option and simplified userResource signature.
> 
> - **Account Provisioning**:
>   - `CreateAccount` now returns `CreateAccountResponse_SuccessResult` with the created `user` resource.
>   - Removed credential option `CAPABILITY_DETAIL_CREDENTIAL_OPTION_RANDOM_PASSWORD`.
> - **Client API**:
>   - `tableau.Client.AddUserToSite` now returns `*User` and validates response.
> - **Refactor**:
>   - Simplified `userResource` signature (removed `context.Context`), updated call sites in `group.go`, `license.go`, `site.go`, and `user.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dec3653885558c79e65f7ce6ee66024006daf75f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Account creation now returns the created user/resource on success, providing immediate details for follow-up.

* Breaking Changes
  * Removed the “Generate Random Password” credential option; passwords must be supplied explicitly.
  * User-add operations now return the created user object or an explicit error on failure.

* Refactor
  * Internal resource-resolution calls simplified with no expected user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->