### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -90,10 +90,18 @@ type Client struct {
 }
 
 // New creates an authenticated Tableau API client.
-func New(ctx context.Context, serverPath, siteID, accessTokenName, accessTokenSecret, apiVersion string) (*Client, error) {
-	baseURL, err := BuildBaseURL(serverPath, apiVersion)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build base URL: %w", err)
+// If baseURLOverride is non-empty, it is used directly instead of building from serverPath/apiVersion.
+// This is intended for testability (e.g. pointing the connector at a local test server).
+func New(ctx context.Context, serverPath, siteID, accessTokenName, accessTokenSecret, apiVersion, baseURLOverride string) (*Client, error) {
+	var baseURL string
+	if baseURLOverride != "" {
+		baseURL = baseURLOverride
+	} else {
+		var err error
+		baseURL, err = BuildBaseURL(serverPath, apiVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build base URL: %w", err)
+		}
 	}
 
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -9,6 +9,7 @@ type Tableau struct {
 	ServerPath string `mapstructure:"server-path"`
 	SiteId string `mapstructure:"site-id"`
 	ApiVersion string `mapstructure:"api-version"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Tableau) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ var (
 		"base-url",
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Tableau API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,12 +40,19 @@ var (
 		field.WithDefaultValue("3.27"),
 	)
 
+	BaseURL = field.StringField(
+		"base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the Tableau API URL (for testing)"),
+	)
+
 	ConfigurationFields = []field.SchemaField{
 		AccessTokenName,
 		AccessTokenSecret,
 		ServerPath,
 		SiteID,
 		APIVersion,
+		BaseURL,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,7 @@ var (
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Tableau API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -43,7 +43,7 @@ func New(ctx context.Context, tc *cfg.Tableau, _ *cli.ConnectorOpts) (connectorb
 		return nil, nil, err
 	}
 
-	tableauClient, err := client.New(ctx, tc.ServerPath, tc.SiteId, tc.AccessTokenName, tc.AccessTokenSecret, tc.ApiVersion)
+	tableauClient, err := client.New(ctx, tc.ServerPath, tc.SiteId, tc.AccessTokenName, tc.AccessTokenSecret, tc.ApiVersion, tc.BaseUrl)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create client: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-tableau/main.go,pkg/config/conf.gen.go,pkg/config/config.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-tableau --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Base URL configuration option to customize the Tableau API endpoint connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->