### PR TITLE
[CXP-295] remove dead authSetting fallback and surface IDP 404 explicitly

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -627,9 +627,9 @@ func (c *Client) DeleteViewGroupPermission(ctx context.Context, viewID, groupID,
 // =============================================================================
 
 // ListIdpConfigurations returns IDP configurations for the site.
-// Returns an empty list if the endpoint is not available (HTTP 404), which
-// can happen when the Tableau site has no external IDP integration or the
-// API version does not support this endpoint.
+// Returns an error (codes.NotFound) if the endpoint is unavailable, which
+// can happen on older on-premises Tableau Server (<2023.3 / API <3.22).
+// Callers are responsible for deciding how to handle the unavailable case.
 func (c *Client) ListIdpConfigurations(ctx context.Context) ([]*IdpConfiguration, annotations.Annotations, error) {
 	urlListIdpConfigurations, err := c.buildSiteURL(pathIdpConfigurations)
 	if err != nil {
@@ -639,10 +639,7 @@ func (c *Client) ListIdpConfigurations(ctx context.Context) ([]*IdpConfiguration
 	var res idpConfigurationsResponse
 	annos, err := c.doRequest(ctx, http.MethodGet, urlListIdpConfigurations, &res, nil)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, annos, nil
-		}
-		return nil, nil, err
+		return nil, annos, err
 	}
 
 	return res.SiteAuthConfigurations.SiteAuthConfiguration, annos, nil

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -13,6 +13,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/conductorone/baton-tableau/pkg/client"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var _ connectorbuilder.AccountManagerV2 = &userBuilder{}
@@ -141,11 +142,6 @@ func (u *userBuilder) CreateAccount(ctx context.Context, accountInfo *v2.Account
 		}
 		if idpID != "" {
 			reqBody.IdpConfigurationId = idpID
-		} else if authSetting, _ := pMap["authSetting"].(string); authSetting != "" {
-			// Fallback for environments where site-auth-configurations is unavailable (e.g. older
-			// on-premises Tableau Server <2023.3). The caller can set authSetting directly
-			// (e.g. "SAML", "OPENID") to control the auth method without IDP discovery.
-			reqBody.AuthSetting = authSetting
 		}
 	}
 
@@ -168,6 +164,10 @@ func (u *userBuilder) selectIDPConfiguration(ctx context.Context, idpConfigName 
 	if idpConfigName != "" {
 		cfg, _, err := u.client.FindIdpConfigurationByName(ctx, idpConfigName)
 		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return "", uhttp.WrapErrors(codes.InvalidArgument,
+					fmt.Sprintf("IDP configuration '%s' cannot be resolved: the site-auth-configurations endpoint is unavailable on this server; upgrade to Tableau Server 2023.3+ (API 3.22+) or remove idpConfigurationName", idpConfigName))
+			}
 			return "", fmt.Errorf("failed to find IDP configuration: %w", err)
 		}
 		if cfg == nil {
@@ -184,6 +184,12 @@ func (u *userBuilder) selectIDPConfiguration(ctx context.Context, idpConfigName 
 
 	enabledConfigs, _, err := u.client.ListEnabledIdpConfigurations(ctx)
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			// Endpoint unavailable on older Tableau Server (<2023.3 / API <3.22).
+			// No idpConfigurationName was requested, so preserve original behavior:
+			// proceed with no auth fields and let Tableau use the site default.
+			return "", nil
+		}
 		return "", fmt.Errorf("failed to list IDP configurations: %w", err)
 	}
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -166,7 +166,8 @@ func (u *userBuilder) selectIDPConfiguration(ctx context.Context, idpConfigName 
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
 				return "", uhttp.WrapErrors(codes.InvalidArgument,
-					fmt.Sprintf("IDP configuration '%s' cannot be resolved: the site-auth-configurations endpoint is unavailable on this server; upgrade to Tableau Server 2023.3+ (API 3.22+) or remove idpConfigurationName", idpConfigName))
+					fmt.Sprintf("IDP configuration '%s' cannot be resolved: site-auth-configurations endpoint unavailable;"+
+						" upgrade to Tableau Server 2023.3+ (API 3.22+) or remove idpConfigurationName", idpConfigName))
 			}
 			return "", fmt.Errorf("failed to find IDP configuration: %w", err)
 		}


### PR DESCRIPTION
## Summary

- **Remove `authSetting` dead code** — this profile field was never added to `ConnectorAccountCreationSchema`, making it invisible in the C1 UI and unreachable through any supported workflow. The block in `CreateAccount` could never execute for a real user.
- **Surface HTTP 404 from `ListIdpConfigurations`** — the client was silently swallowing 404 responses (returning `nil, nil, nil`). The 404 handling is now moved to `selectIDPConfiguration` where it has context to decide the right behavior.
- **Backward-compatible** — the two IDP paths behave differently by design:
  - _Nothing configured_: 404 → `return "", nil` → no auth fields set → Tableau site default. This is the original pre-IDP-feature behavior, preserved for all API versions.
  - _`idpConfigurationName` set_: 404 → explicit `InvalidArgument` error with an actionable message. The customer opted into IDP-based auth, so the endpoint must be available.

## Analysis

### Why `authSetting` was dead code

The `authSetting` block (added in #40) read from the raw profile map `pMap["authSetting"]`. Because it was never in the schema, the only way to populate it was via a hand-crafted raw profile API call — not through the C1 UI, not through standard connector config. In practice: the block never executed.

No deprecation warning is needed — there is nothing to deprecate.

### Why silently swallowing the 404 was a bug

`ListIdpConfigurations` returning `nil, nil, nil` on 404 caused a silent misconfiguration path:

> A customer configures `idpConfigurationName` to provision accounts under a specific IDP (e.g. SAML). On an older Tableau Server where the endpoint is unavailable, `FindIdpConfigurationByName` returns `nil` (no error — 404 swallowed), `selectIDPConfiguration` returns `""`, and `CreateAccount` proceeds with no auth fields set. Tableau silently uses the site default instead of the requested IDP. The account is created successfully — but with the wrong auth method, and the customer has no indication anything went wrong.

This produces **inconsistent account creations**: accounts provisioned on newer servers get the correct IDP, accounts provisioned on older servers silently get a different auth method. Before this fix there was no way to distinguish "endpoint unavailable" from "endpoint available but empty".

### Backward compatibility

The fix preserves backward compatibility because the two cases are intentionally different:

| Situation | Before | After |
|---|---|---|
| Nothing configured, endpoint 404s (old on-prem) | No auth fields → site default | No auth fields → site default ✅ |
| Nothing configured, 0 enabled IDPs | No auth fields → site default | No auth fields → site default ✅ |
| Nothing configured, 1 enabled IDP | Uses that IDP | Uses that IDP ✅ |
| `idpConfigurationName` set, found | Uses named IDP | Uses named IDP ✅ |
| `idpConfigurationName` set, not found | Error: "not found" | Error: "not found" ✅ |
| `idpConfigurationName` set, endpoint 404s | **Silent fallback to site default** ❌ | Error: "endpoint unavailable, upgrade or remove field" ✅ |
| `authSetting` in raw profile | Sets `AuthSetting` directly | No effect (field removed) ✅ |

If nothing is configured, the 404 is still silently ignored — that is intentional and preserves the original behavior. If `idpConfigurationName` is explicitly set, the endpoint **must** be available; silently ignoring the failure there was the bug.

## Test plan

- [ ] Create account with no IDP fields configured — should succeed using Tableau site default
- [ ] Create account with valid `idpConfigurationName` — should use the named IDP
- [ ] Create account with invalid `idpConfigurationName` — should error listing available IDPs
- [ ] On a server with API <3.22: create account with no IDP fields — should succeed (site default)
- [ ] On a server with API <3.22: create account with `idpConfigurationName` set — should error with endpoint-unavailable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)