### PR TITLE
docs: document IDP Configuration Name, With MFA provisioning fields, and api-version config field

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -126,6 +126,9 @@ Enter the name of the personal access token into the **Access token name** field
 Enter the personal access token value into the **Access token secret** field. 
 </Step>
 <Step>
+Optionally, enter a value in the **API Version** field to override the default Tableau API version (default: `3.27`). Only change this if your Tableau Server instance requires a specific API version.
+</Step>
+<Step>
 Click **Save**.
 </Step>
 <Step>
@@ -204,6 +207,10 @@ stringData:
   BATON_SERVER_PATH: <Base URL for your Tableau server>
   BATON_SITE_ID: <Tableau site ID>
 
+  # Optional: override the Tableau API version (default: 3.27)
+  # Only set this if your Tableau Server requires a specific API version.
+  # BATON_API_VERSION: "3.27"
+
   # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```
@@ -258,5 +265,27 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Tab>
 </Tabs>
 
+## Configure IDP-based account provisioning
 
+When provisioning Tableau accounts (Licenses resource type), the connector supports two optional fields in the provisioning mapping that control how new accounts are authenticated:
 
+| Field | Description |
+| --- | --- |
+| **IDP Configuration Name** | Name of an IDP configuration defined on your Tableau site (e.g., a SAML provider). When set, new accounts are created using that IDP. Requires Tableau API version ≥ 3.22. |
+| **With MFA** | When set to `true`, new accounts are created using Tableau's built-in MFA authentication. Takes precedence over **IDP Configuration Name** if both are set. |
+
+These fields appear in the **provisioning mapping** for the Licenses entitlement in C1 and are not part of the connector's base configuration.
+
+### Behavior reference
+
+| Configuration | Result |
+| --- | --- |
+| Neither field set | Account created with Tableau site default authentication |
+| **IDP Configuration Name** set, IDP found | Account created with the named IDP |
+| **IDP Configuration Name** set, IDP not found | Provisioning fails with an explicit error naming the missing IDP |
+| **IDP Configuration Name** set, API version < 3.22 | Provisioning fails with an explicit error — upgrade your Tableau Server or remove the field |
+| **With MFA** = `true` | Account created with Tableau MFA — **IDP Configuration Name** is ignored regardless of API version |
+
+<Note>
+If your Tableau Server uses an API version older than 3.22 and you do not set **IDP Configuration Name**, account provisioning uses the site default authentication without error. The IDP endpoint is only required when you explicitly configure an IDP name.
+</Note>

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -126,9 +126,6 @@ Enter the name of the personal access token into the **Access token name** field
 Enter the personal access token value into the **Access token secret** field. 
 </Step>
 <Step>
-Optionally, enter a value in the **API Version** field to override the default Tableau API version (default: `3.27`). Only change this if your Tableau Server instance requires a specific API version.
-</Step>
-<Step>
 Click **Save**.
 </Step>
 <Step>


### PR DESCRIPTION
## Summary

The official documentation at https://www.c1.ai/docs/baton/tableau was missing several fields that have existed in the connector for some time:

- **`api-version` config field** (default: 3.27) — visible in C1 connector settings but not documented
- **`IDP Configuration Name` provisioning field** — in account creation schema since PR #29 (CXH-97, v0.1.11), never documented
- **`With MFA` provisioning field** — in account creation schema since PR #29 (CXH-97, v0.1.11), never documented
- **IDP provisioning behavior matrix** — documents all flag combinations and expected outcomes
- **v0.1.13 behavior change** — when `IDP Configuration Name` is set and API version < 3.22, connector now returns an explicit error instead of silently falling back to site default auth (PR #41, CXP-295)

## Related

- Linear: CXP-295 — Tableau Connector: viewer license provisioning failing due to IDP 404
- PR #41: remove dead authSetting fallback and surface IDP 404 explicitly
- PR #29: CXH-97 add more options for idp when creating users (original introduction of IDP/MFA fields)