### PR TITLE
[CXH-1933] - Add License data with purchased and consumed seat counts - Tableau Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ baton resources
 - **Sites** — The Tableau site the connector is authenticated against (top-level resource)
 - **Users** — All users on the site with email, site role, auth setting, and last login
 - **Groups** — Tableau groups with membership information
-- **Licenses** — License tiers (Creator, Explorer, Viewer, Unlicensed) with role-based assignment
+- **Licenses** — License tiers (Creator, Explorer, Viewer, Unlicensed) with role-based assignment and purchased/consumed seat counts
 - **Projects** — Tableau projects with Read/Write permission assignments for users and groups
 - **Workbooks** — Tableau workbooks with 15 granular permission assignments for users and groups
 - **Views** — Individual dashboards/views with granular permissions (inherited from workbook when `showTabs=true`)

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -20,7 +20,8 @@
         "id": "license",
         "displayName": "License",
         "traits": [
-          "TRAIT_ROLE"
+          "TRAIT_ROLE",
+          "TRAIT_LICENSE_PROFILE"
         ]
       },
       "capabilities": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -20,6 +20,19 @@ sidebarTitle: Salesforce Tableau
 
 The Tableau connector supports [automatic account provisioning and deprovisioning](/product/admin/account-provisioning).
 
+## Licenses and seats
+
+In Tableau, licensing is role-based: each user's **site role** determines their license tier. There is no separate license object to assign — granting a license means setting the user's site role. The connector surfaces four tiers:
+
+- **Creator** — full authoring, data preparation, and publishing
+- **Explorer** — browse, interact, and publish with existing data sources
+- **Viewer** — view and interact with published dashboards
+- **Unlicensed** — no access to site features
+
+<Note>
+When your Tableau site has per-tier seat capacities configured, C1 tracks the purchased and consumed seat counts for each license tier, so you can review license utilization alongside who holds each tier.
+</Note>
+
 ## Permission inheritance
 
 Tableau uses a permission inheritance model that affects how access is synced and provisioned:

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -319,7 +319,7 @@
 
 - Users with unknown or unexpected site roles (not in the connector's role map) are **skipped** during site grant sync instead of creating malformed grants. A warning is logged.
 - The role map covers all valid [Tableau REST API site roles](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_new_site_roles.htm): `SiteAdministratorCreator`, `SiteAdministratorExplorer`, `SiteAdministrator`, `Creator`, `Explorer`, `ExplorerCanPublish`, `Viewer`, `Unlicensed`.
-- `ServerAdministrator` is synced (read-only) but grant attempts are blocked — it is a server-level role that cannot be assigned via the sites API.
+- `ServerAdministrator` is synced (read-only) and consumes a Creator license, but it is never a grant target — the assignable license is Creator, and the `ServerAdministrator` role itself cannot be set via the sites API.
 
 ### License Grants
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -180,7 +180,7 @@
 ### Licenses
 
 - **Description**: Tableau license tiers that determine feature access
-- **Traits**: Role trait
+- **Traits**: Role trait + License Profile trait. The License Profile trait is what lets C1 recognize each tier as a license (with seat counts) instead of a generic role.
 - **Static Resources** (4 license types):
   - `Creator` — Full authoring, data prep, and publishing capabilities
   - `Explorer` — Browse, interact, and publish with existing data sources
@@ -188,6 +188,10 @@
   - `Unlicensed` — No access to Tableau site features
 - **Entitlements**:
   - `member` — License is assigned to user (static entitlement)
+- **Seat counts** (License Profile trait):
+  - **Purchased** — read from the site's per-tier capacity fields (`tierCreatorCapacity`, `tierExplorerCapacity`, `tierViewerCapacity`), which the Tableau API returns as JSON strings. Attached only when the value is a positive number; a `0` or absent capacity attaches no seats (avoids rendering "0 of 0"). The `Unlicensed` floor tier is never capped.
+  - **Consumed** — counted server-side per tier via the users `siteRole` filter, reading `pagination.totalAvailable` (one request per tier instead of walking every user page).
+  - Both are attached via `WithLicenseSeats` only when the tier is capped. Seat enrichment is best-effort: a failed site or count call still syncs the license resources, just without seats.
 - **Provisioning**:
   - Grant: Assign a license to a user by updating their site role
   - Revoke: Remove a license by setting the user's site role to Unlicensed
@@ -196,12 +200,12 @@
 >
 > | License | Site Roles Included |
 > |---|---|
-> | Creator | `Creator`, `SiteAdministratorCreator` |
+> | Creator | `Creator`, `SiteAdministratorCreator`, `ServerAdministrator` |
 > | Explorer | `Explorer`, `SiteAdministratorExplorer`, `ExplorerCanPublish`, `SiteAdministrator` |
 > | Viewer | `Viewer` |
 > | Unlicensed | `Unlicensed` |
 >
-> `SiteAdministrator` is a legacy role (maps to `SiteAdministratorExplorer`) that cannot be used with the Tableau REST API filter endpoint, so the connector fetches all users and filters client-side when processing Explorer license grants. See [Tableau REST API Site Roles](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_new_site_roles.htm) for the full role reference.
+> `SiteAdministrator` is a legacy role (maps to `SiteAdministratorExplorer`) that cannot be used with the Tableau REST API filter endpoint, so the connector fetches all users and filters client-side when processing Explorer license grants. `ServerAdministrator` consumes a Creator license per Tableau's licensing model and is counted under the Creator tier (sync only — it cannot be assigned via the sites API). See [Tableau REST API Site Roles](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_new_site_roles.htm) for the full role reference.
 
 > **Important — License Revoke Constraints**: Revoking a license (setting a user to "Unlicensed") will fail if the user belongs to a group with "Grant role on sign in" configured. Tableau enforces that a user's site role cannot be lower than the minimum site role required by any group they belong to. The error message from Tableau will be: *"Site role of link user that belongs to license upon login cannot be lower than minimum site role of group"*. To resolve this, remove the user from the constraining group first, then revoke the license.
 
@@ -321,6 +325,7 @@
 
 - The Explorer license includes `SiteAdministrator` (legacy role). This role is not supported by the Tableau API's `siteRole` filter, so the connector falls back to fetching all users and filtering client-side for the Explorer license.
 - For Creator, Viewer, and Unlicensed licenses, server-side filtering is used for efficiency.
+- Consumed-seat counts reuse the same server-side `siteRole` filter but read only `pagination.totalAvailable` per tier (no full user walk). The Explorer count excludes the unfilterable legacy `SiteAdministrator` role, which does not exist on Tableau Cloud.
 
 ### View Grants and showTabs
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ennyjfrick/ruleguard-logfatal v0.0.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
+	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
@@ -104,7 +105,6 @@ require (
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -67,6 +67,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -224,6 +225,28 @@ func (c *Client) GetUsers(ctx context.Context, pageToken string, opts ...ReqOpt)
 
 	nextToken := getNextPageToken(page, res.Pagination)
 	return res.Users.User, nextToken, annos, nil
+}
+
+// CountUsers returns how many site users match the given filters, read from the
+// pagination total without fetching the user records.
+func (c *Client) CountUsers(ctx context.Context, opts ...ReqOpt) (int64, annotations.Annotations, error) {
+	urlCountUsers, err := c.buildSiteURL(pathUsers)
+	if err != nil {
+		return 0, nil, err
+	}
+	applyOpts(urlCountUsers, append([]ReqOpt{withIntParam("pageSize", 1), withIntParam("pageNumber", 1)}, opts...)...)
+
+	var res usersResponse
+	annos, err := c.doRequest(ctx, http.MethodGet, urlCountUsers, &res, nil)
+	if err != nil {
+		return 0, annos, err
+	}
+
+	total, err := strconv.Atoi(res.Pagination.TotalAvailable)
+	if err != nil {
+		return 0, annos, fmt.Errorf("invalid totalAvailable %q: %w", res.Pagination.TotalAvailable, err)
+	}
+	return int64(total), annos, nil
 }
 
 // AddUserToSite creates a new user on the site.

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -12,19 +12,25 @@ type Credentials struct {
 	EstimatedTimeToExpiration string `json:"estimatedTimeToExpiration"`
 }
 
+// Site tier capacities are the purchased seats per license. Tableau returns them
+// as JSON strings and only when caps are configured, so they are string pointers:
+// nil (unset) is distinct from "0" (uncapped tier).
 type Site struct {
-	ID         string `json:"id"`
-	ContentURL string `json:"contentUrl"`
-	Name       string `json:"name"`
+	ID                   string  `json:"id"`
+	ContentURL           string  `json:"contentUrl"`
+	Name                 string  `json:"name"`
+	TierCreatorCapacity  *string `json:"tierCreatorCapacity,omitempty"`
+	TierExplorerCapacity *string `json:"tierExplorerCapacity,omitempty"`
+	TierViewerCapacity   *string `json:"tierViewerCapacity,omitempty"`
 }
 
 type User struct {
-	Email       string    `json:"email"`
-	ID          string    `json:"id"`
-	FullName    string    `json:"fullName"`
-	Name        string    `json:"name"`
-	SiteRole    string    `json:"siteRole"`
-	AuthSetting string    `json:"authSetting"`
+	Email       string     `json:"email"`
+	ID          string     `json:"id"`
+	FullName    string     `json:"fullName"`
+	Name        string     `json:"name"`
+	SiteRole    string     `json:"siteRole"`
+	AuthSetting string     `json:"authSetting"`
 	LastLogin   *time.Time `json:"lastLogin"`
 }
 

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -133,7 +133,7 @@ func (l *licenseBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOp
 	consumed := map[string]int64{}
 	countOK := false
 	if hasTierCapacity(site) {
-		consumedByTier, cErr := l.countConsumedByTier(ctx)
+		consumedByTier, cErr := l.countConsumedByTier(ctx, site)
 		if cErr != nil {
 			log.Debug("failed to count consumed license seats; syncing licenses without seat counts", zap.Error(cErr))
 		} else {
@@ -158,11 +158,14 @@ func (l *licenseBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOp
 	return rv, nil, nil
 }
 
-// countConsumedByTier counts users per license tier server-side via the site-role
+// countConsumedByTier counts users server-side per capped tier via the site-role
 // filter, reading the pagination total instead of paging through every user.
-func (l *licenseBuilder) countConsumedByTier(ctx context.Context) (map[string]int64, error) {
+func (l *licenseBuilder) countConsumedByTier(ctx context.Context, site *client.Site) (map[string]int64, error) {
 	consumed := make(map[string]int64, len(licenses))
 	for _, license := range licenses {
+		if _, ok := capacitySeats(licenseCapacity(license, site)); !ok {
+			continue
+		}
 		filterable := filterableRoles(RolesPerLicense[license])
 		if len(filterable) == 0 {
 			continue

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -3,28 +3,77 @@ package connector
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
-	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-tableau/pkg/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 var licenses = []string{creator, explorer, viewer, unlicensed}
+
 var licensesMap = map[string]string{
 	"creator":    creator,
 	"explorer":   explorer,
 	"viewer":     viewer,
 	"unlicensed": unlicensed,
 }
+
+// RolesPerLicense groups the Tableau site roles that consume each license tier.
+// Doc: https://help.tableau.com/current/server/en-us/permission_license_siterole.htm
 var RolesPerLicense = map[string][]string{
-	creator:    {creator, siteAdministratorCreator},
+	creator:    {creator, siteAdministratorCreator, serverAdministrator},
 	explorer:   {explorer, siteAdministratorExplorer, explorerCanPublish, siteAdministrator},
 	viewer:     {viewer},
 	unlicensed: {unlicensed},
+}
+
+// licenseCapacity returns the raw per-tier capacity string, or nil when the site exposes none.
+func licenseCapacity(license string, site *client.Site) *string {
+	if site == nil {
+		return nil
+	}
+	switch license {
+	case creator:
+		return site.TierCreatorCapacity
+	case explorer:
+		return site.TierExplorerCapacity
+	case viewer:
+		return site.TierViewerCapacity
+	default:
+		return nil
+	}
+}
+
+// capacitySeats parses a tier-capacity string, reporting seats only for a positive cap.
+func capacitySeats(capacity *string) (int64, bool) {
+	if capacity == nil {
+		return 0, false
+	}
+	netSeats, err := strconv.ParseInt(strings.TrimSpace(*capacity), 10, 64)
+	if err != nil || netSeats <= 0 {
+		return 0, false
+	}
+	return netSeats, true
+}
+
+// hasTierCapacity reports whether the site exposes any positive per-tier capacity.
+func hasTierCapacity(site *client.Site) bool {
+	if site == nil {
+		return false
+	}
+	for _, capacity := range []*string{site.TierCreatorCapacity, site.TierExplorerCapacity, site.TierViewerCapacity} {
+		if _, ok := capacitySeats(capacity); ok {
+			return true
+		}
+	}
+	return false
 }
 
 type licenseBuilder struct {
@@ -35,8 +84,8 @@ func (l *licenseBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return resourceTypeLicense
 }
 
-// Create a new connector resource for a Tableau License.
-func licenseResource(license string) (*v2.Resource, error) {
+// licenseResource builds a License resource, attaching seat counts only when the tier is capped.
+func licenseResource(license string, purchased *string, consumed int64) (*v2.Resource, error) {
 	licenseID := strings.ToLower(license)
 	profile := map[string]any{
 		"license_name": license,
@@ -47,7 +96,23 @@ func licenseResource(license string) (*v2.Resource, error) {
 		rs.WithRoleProfile(profile),
 	}
 
-	ret, err := rs.NewRoleResource(license, resourceTypeLicense, licenseID, roleTraitOptions)
+	stub := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: resourceTypeLicense.Id,
+			Resource:     licenseID,
+		},
+	}
+	licenseTraitOptions := []rs.LicenseProfileTraitOption{
+		rs.WithLicenseName(license),
+		rs.WithLicenseEntitlementIDs(ent.NewEntitlementID(stub, memberEntitlement)),
+	}
+	if seats, ok := capacitySeats(purchased); ok {
+		licenseTraitOptions = append(licenseTraitOptions, rs.WithLicenseSeats(seats, consumed))
+	}
+
+	ret, err := rs.NewRoleResource(license, resourceTypeLicense, licenseID, roleTraitOptions,
+		rs.WithLicenseProfileTrait(licenseTraitOptions...),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -55,24 +120,67 @@ func licenseResource(license string) (*v2.Resource, error) {
 	return ret, nil
 }
 
-func (l *licenseBuilder) List(_ context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	var rv []*v2.Resource
+// List emits the four license tiers, enriched with purchased/consumed seats on a best-effort basis.
+func (l *licenseBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	log := ctxzap.Extract(ctx)
 
+	site, _, err := l.client.GetSite(ctx)
+	if err != nil {
+		log.Debug("failed to get site for license capacities; syncing licenses without seat counts", zap.Error(err))
+		site = nil
+	}
+
+	consumed := map[string]int64{}
+	countOK := false
+	if hasTierCapacity(site) {
+		consumedByTier, cErr := l.countConsumedByTier(ctx)
+		if cErr != nil {
+			log.Debug("failed to count consumed license seats; syncing licenses without seat counts", zap.Error(cErr))
+		} else {
+			consumed = consumedByTier
+			countOK = true
+		}
+	}
+
+	var rv []*v2.Resource
 	for _, license := range licenses {
-		sr, err := licenseResource(license)
+		var purchased *string
+		if countOK {
+			purchased = licenseCapacity(license, site)
+		}
+		res, err := licenseResource(license, purchased, consumed[license])
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create license resource %s: %w", license, err)
 		}
-		rv = append(rv, sr)
+		rv = append(rv, res)
 	}
 
 	return rv, nil, nil
+}
+
+// countConsumedByTier counts users per license tier server-side via the site-role
+// filter, reading the pagination total instead of paging through every user.
+func (l *licenseBuilder) countConsumedByTier(ctx context.Context) (map[string]int64, error) {
+	consumed := make(map[string]int64, len(licenses))
+	for _, license := range licenses {
+		filterable := filterableRoles(RolesPerLicense[license])
+		if len(filterable) == 0 {
+			continue
+		}
+		count, _, err := l.client.CountUsers(ctx, siteRoleFilter(filterable))
+		if err != nil {
+			return nil, fmt.Errorf("failed to count %s users: %w", license, err)
+		}
+		consumed[license] = count
+	}
+	return consumed, nil
 }
 
 func (l *licenseBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	return nil, nil, nil
 }
 
+// StaticEntitlements declares the single "member" entitlement every license tier exposes.
 func (l *licenseBuilder) StaticEntitlements(_ context.Context, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	en := ent.NewAssignmentEntitlement(
 		nil,
@@ -85,6 +193,7 @@ func (l *licenseBuilder) StaticEntitlements(_ context.Context, _ rs.SyncOpAttrs)
 	return []*v2.Entitlement{en}, nil, nil
 }
 
+// Grants emits one member grant per user holding a site role that consumes this tier.
 func (l *licenseBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	allRoles := RolesPerLicense[resource.DisplayName]
 	if len(allRoles) == 0 {
@@ -126,6 +235,7 @@ func (l *licenseBuilder) Grants(ctx context.Context, resource *v2.Resource, opts
 	return rv, &rs.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
+// Grant assigns the target license tier by setting the user's site role.
 func (l *licenseBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
 	licenseName, ok := licensesMap[entitlement.Resource.Id.Resource]
 	if !ok {
@@ -140,6 +250,7 @@ func (l *licenseBuilder) Grant(ctx context.Context, principal *v2.Resource, enti
 	return annos, nil
 }
 
+// Revoke removes the license by setting the user's site role to Unlicensed.
 func (l *licenseBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
 	principalID := grant.Principal.Id.Resource
 

--- a/pkg/connector/license_test.go
+++ b/pkg/connector/license_test.go
@@ -1,0 +1,109 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLicenseResource_Trait asserts the LicenseProfileTrait is attached with the
+// right name, entitlement ID, and seat counts. The baton CLI does not decode the
+// trait body, so this direct assertion is the reliable verification path.
+func TestLicenseResource_Trait(t *testing.T) {
+	t.Parallel()
+
+	creatorCap := "5"
+	zeroCap := "0"
+
+	tests := []struct {
+		name          string
+		license       string
+		purchased     *string
+		consumed      int64
+		wantName      string
+		wantEntID     string
+		wantPurchased int64
+		wantConsumed  int64
+	}{
+		{
+			name:          "capped tier reports seats",
+			license:       creator,
+			purchased:     &creatorCap,
+			consumed:      2,
+			wantName:      "Creator",
+			wantEntID:     "license:creator:member",
+			wantPurchased: 5,
+			wantConsumed:  2,
+		},
+		{
+			name:      "floor tier without capacity omits seats",
+			license:   unlicensed,
+			purchased: nil,
+			consumed:  0,
+			wantName:  "Unlicensed",
+			wantEntID: "license:unlicensed:member",
+			// no capacity -> WithLicenseSeats not called -> both zero
+			wantPurchased: 0,
+			wantConsumed:  0,
+		},
+		{
+			name:      "zero capacity omits seats",
+			license:   viewer,
+			purchased: &zeroCap,
+			consumed:  3,
+			wantName:  "Viewer",
+			wantEntID: "license:viewer:member",
+			// "0" capacity -> WithLicenseSeats not called (no "0 of N")
+			wantPurchased: 0,
+			wantConsumed:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := licenseResource(tt.license, tt.purchased, tt.consumed)
+			require.NoError(t, err)
+
+			profile, err := resource.GetLicenseProfileTrait(res)
+			require.NoError(t, err, "license resource must carry a LicenseProfileTrait")
+
+			require.Equal(t, tt.wantName, profile.GetLicenseName())
+			require.Equal(t, []string{tt.wantEntID}, profile.GetEntitlementIds())
+			require.Equal(t, tt.wantPurchased, profile.GetPurchasedSeats())
+			require.Equal(t, tt.wantConsumed, profile.GetConsumedSeats())
+		})
+	}
+}
+
+// TestCapacitySeats locks in the parse + positive-guard contract: only a
+// present, numeric, positive capacity string yields seats.
+func TestCapacitySeats(t *testing.T) {
+	t.Parallel()
+
+	str := func(s string) *string { return &s }
+	tests := []struct {
+		name   string
+		in     *string
+		wantN  int64
+		wantOK bool
+	}{
+		{name: "nil", in: nil, wantN: 0, wantOK: false},
+		{name: "positive", in: str("25"), wantN: 25, wantOK: true},
+		{name: "zero", in: str("0"), wantN: 0, wantOK: false},
+		{name: "whitespace-padded", in: str("  7 "), wantN: 7, wantOK: true},
+		{name: "negative", in: str("-3"), wantN: 0, wantOK: false},
+		{name: "non-numeric", in: str("unlimited"), wantN: 0, wantOK: false},
+		{name: "empty", in: str(""), wantN: 0, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n, ok := capacitySeats(tt.in)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantN, n)
+		})
+	}
+}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -30,6 +30,7 @@ var (
 		DisplayName: "License",
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_ROLE,
+			v2.ResourceType_TRAIT_LICENSE_PROFILE,
 		},
 	}
 	resourceTypeProject = &v2.ResourceType{


### PR DESCRIPTION
## Description
- [x] New feature

Adds license consumption data to the Tableau connector (CXH-1933). The `License` resource already synced (as a role, with `member` entitlements and per-user grants), but C1 could not recognize it as a license. This attaches a `LicenseProfileTrait` to each tier so the platform can map the resource to its licensing model and, where the site exposes per-tier capacities, surface purchased vs consumed seats. On Tableau Cloud the synced surface (resources, entitlements, grants) is identical to `main`; on Tableau Server, the Creator tier now additionally grants `ServerAdministrator` users, which correctly consume a Creator license.

### Sync:

- **Licenses** (`license`) — each tier now carries a `LicenseProfileTrait` (license name, `member` entitlement ID, and purchased/consumed seat counts). `ServerAdministrator` is now attributed to the **Creator** tier. Resource and entitlement counts are unchanged; grant counts are unchanged on Cloud, and on Tableau Server the Creator tier now also grants `ServerAdministrator` users (they consume a Creator license).
- **Users / Groups / Sites / Projects / Workbooks / Views** — unchanged.

### Provisioning:

- Unchanged. License `Grant`/`Revoke` are identical to `main` (grant sets the site role, revoke sets `Unlicensed`).

### Auth:

- Unchanged. No new flags or configuration.

### Architecture highlights:

- **Purchased seats** come from the site per-tier capacities (`tierCreatorCapacity`, `tierExplorerCapacity`, `tierViewerCapacity`), which Tableau returns as JSON strings. Stored as `*string` so `nil` (unset) is distinct from `"0"` (uncapped); seats are attached via `WithLicenseSeats` only when the value is a positive number.
- **Consumed seats** are counted server-side per tier via the users `siteRole` filter, reading `pagination.totalAvailable` (one request per tier instead of walking every user page).
- **Best-effort enrichment** — a failed site fetch or count logs at debug and still syncs the licenses without seats.
- `ServerAdministrator` was verified against the live API as an accepted `siteRole` filter value (the legacy `SiteAdministrator` NPEs and is already excluded).
- **Tableau Server caveat (documented):** the Explorer consumed count filters server-side and drops the legacy `SiteAdministrator` role, while grants include those users via a client-side pass — so on Server with legacy `SiteAdministrator` users, Explorer consumed can under-report vs the emitted grants. The bare `SiteAdministrator` role only exists on Server (Cloud uses `SiteAdministratorExplorer`/`Creator`), so Cloud is exact.
- **Platform note:** C1 does not yet ingest/render `LicenseProfileTrait` seat counts (same gap observed on baton-notion and baton-zoom). The connector side is forward-compatible — the trait is emitted correctly for when the platform adds support.

### Useful links:

- [Linear ticket CXH-1933 — Add license data (Tableau)](https://linear.app/ductone/issue/CXH-1933/add-license-data-tableau)
- [Tableau REST API — Site Roles](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_new_site_roles.htm)
- [Tableau — License and site role reference](https://help.tableau.com/current/server/en-us/permission_license_siterole.htm)
