### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -40,13 +40,14 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId) (*v2.Re
 		"group_name": group.Name,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{rs.WithGroupProfile(profile)}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		group.Name,
 		resourceTypeGroup,
 		group.ID,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
@@ -94,12 +95,7 @@ func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 }
 
 func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get group trait: %w", err)
-	}
-
-	groupId, ok := rs.GetProfileStringValue(groupTrait.Profile, "group_id")
+	groupId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "group_id")
 	if !ok {
 		return nil, nil, fmt.Errorf("missing group_id in group profile")
 	}

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -92,9 +92,7 @@ func licenseResource(license string, purchased *string, consumed int64) (*v2.Res
 		"license_id":   licenseID,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraitOptions := []rs.RoleTraitOption{}
 
 	stub := &v2.Resource{
 		Id: &v2.ResourceId{
@@ -111,6 +109,7 @@ func licenseResource(license string, purchased *string, consumed int64) (*v2.Res
 	}
 
 	ret, err := rs.NewRoleResource(license, resourceTypeLicense, licenseID, roleTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithLicenseProfileTrait(licenseTraitOptions...),
 	)
 	if err != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -47,8 +47,6 @@ func userResource(user *client.User, parentResourceID *v2.ResourceId) (*v2.Resou
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 		rs.WithEmail(user.Email, true),
 	}
 	if user.LastLogin != nil {
@@ -60,6 +58,8 @@ func userResource(user *client.User, parentResourceID *v2.ResourceId) (*v2.Resou
 		resourceTypeUser,
 		user.ID,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 		rs.WithParentResourceID(parentResourceID),
 		rs.WithExternalID(&v2.ExternalId{Id: user.ID}),
 	)


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
